### PR TITLE
fix:docker-compose healthecheck error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     healthcheck:
       test:
         [
+          "CMD-SHELL",
           "/lightflus/runtime/tools/healthcheck",
           "-TARGET localhost:8791",
           "-METHOD /proto.CoordinatorApi/Probe",
@@ -56,6 +57,7 @@ services:
     healthcheck:
       test:
         [
+          "CMD-SHELL",
           "/lightflus/runtime/tools/healthcheck",
           "-TARGET localhost:18090",
           "-METHOD /proto.TaskWorkerApi/Probe",


### PR DESCRIPTION
```bash
co1a@WorkStation:~/project/lightflus$ docker-compose up
ERROR: Service "coordinator" defines an invalid healthcheck: when "test" is a list the first item must be either NONE, CMD or CMD-SHELL
```