### PR TITLE
fix:rocksdb-dev no longger support alpine 3.15

### DIFF
--- a/docker/coordinator/Dockerfile
+++ b/docker/coordinator/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo install --path src/coordinator
 COPY target/release/coordinator /lightflus/runtime/coordinator
 COPY src/coordinator/etc /lightflus/runtime
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN apk add --update --no-cache rocksdb-dev
 WORKDIR /lightflus/runtime
 COPY --from=builder /lightflus/runtime/etc /lightflus/runtime/etc

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo install --path src/worker
 COPY target/release/worker /lightflus/runtime/worker
 COPY src/worker/etc /lightflus/runtime
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN apk add --update --no-cache rocksdb-dev
 WORKDIR /lightflus/runtime
 COPY --from=builder /lightflus/runtime/etc /lightflus/runtime/etc


### PR DESCRIPTION
Alpine v3.15 no longer supoort rocksdb-dev
https://pkgs.alpinelinux.org/packages?name=rocksdb-dev&branch=v3.15&repo=&arch=&maintainer=