### PR TITLE
[feat/LIG-31] 1. done gracefully close dataflow; 2. using async_trait instead of tonic::async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
 name = "stream"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "chrono",
  "common",

--- a/src/common/src/db.rs
+++ b/src/common/src/db.rs
@@ -1,4 +1,5 @@
 use futures_util::{TryFuture, TryStreamExt};
+use prost::Message;
 use proto::common::mysql_desc;
 use sqlx::{Arguments, ConnectOptions};
 
@@ -62,6 +63,10 @@ impl MysqlConn {
             .database(&self.conn_opts.database);
 
         opts.connect().await
+    }
+
+    pub fn close(&mut self) {
+        self.conn_opts.clear()
     }
 }
 

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -21,6 +21,7 @@ prost = "0.11"
 prost-types = "0.11"
 rayon = "1.5"
 tracing = "0.1"
+async-trait = "0.1.58"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "macros"] }

--- a/src/stream/src/actor.rs
+++ b/src/stream/src/actor.rs
@@ -660,7 +660,6 @@ impl Sink for SinkImpl {
         }
     }
 
-    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         match self {
             SinkImpl::Local(sink) => sink.close_sink(),
@@ -792,6 +791,7 @@ impl Source for Kafka {
 
     fn close_source(&mut self) {
         self.conf.clear();
+        self.job_id.clear();
         drop(self.connector_id);
         self.consumer.iter().for_each(|consumer| {
             consumer.unsubscribe();
@@ -833,7 +833,6 @@ impl Sink for Kafka {
         }
     }
 
-    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         drop(self.connector_id);
         self.conf.clear();
@@ -917,7 +916,6 @@ impl Sink for Mysql {
         }
     }
 
-    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         self.conn.close();
         self.extractors.clear();
@@ -1018,7 +1016,14 @@ fn extract_arguments(
 
 #[cfg(test)]
 mod tests {
-    use proto::common::{mysql_desc, operator_info::Details, sink, Entry};
+    use proto::common::{
+        mysql_desc, operator_info::Details, redis_desc, sink, Entry, Func, KafkaDesc, MysqlDesc,
+        RedisDesc, ResourceId,
+    };
+
+    use crate::actor::Sink;
+
+    use super::Source;
 
     struct SetupGuard {}
 
@@ -1160,5 +1165,93 @@ mod tests {
                 TypedValue::String("value".to_string())
             ]]
         )
+    }
+
+    #[tokio::test]
+    async fn test_kafka_source_sink_close() {
+        let job_id = ResourceId {
+            resource_id: "resource_id".to_string(),
+            namespace_id: "ns_id".to_string(),
+        };
+        let desc = KafkaDesc {
+            brokers: vec!["localhost:9092".to_string()],
+            topic: "topic".to_string(),
+            opts: None,
+            data_type: 6,
+        };
+        let mut kafka_source = super::Kafka::with_source_config(&job_id, 0, &desc);
+
+        let mut kafka_sink = super::Kafka::with_sink_config(&job_id, 0, &desc);
+
+        kafka_source.close_source();
+        assert_eq!(
+            &kafka_source.conf,
+            &KafkaDesc {
+                brokers: vec![],
+                topic: Default::default(),
+                opts: None,
+                data_type: 0,
+            }
+        );
+        assert_eq!(&kafka_source.job_id, &ResourceId::default());
+
+        kafka_sink.close_sink();
+        assert_eq!(
+            &kafka_sink.conf,
+            &KafkaDesc {
+                brokers: vec![],
+                topic: Default::default(),
+                opts: None,
+                data_type: 0,
+            }
+        );
+        assert_eq!(&kafka_sink.job_id, &ResourceId::default());
+    }
+
+    #[test]
+    fn test_redis_source_sink_close() {
+        let desc = RedisDesc {
+            connection_opts: Some(redis_desc::ConnectionOpts {
+                host: "localhost".to_string(),
+                username: Default::default(),
+                password: Default::default(),
+                database: 0,
+                tls: false,
+            }),
+            key_extractor: Some(Func {
+                function: "key_extractor".to_string(),
+            }),
+            value_extractor: Some(Func {
+                function: "value_extractor".to_string(),
+            }),
+        };
+        let mut redis_sink = super::Redis::with_config(0, &desc);
+
+        redis_sink.close_sink();
+        assert_eq!(&redis_sink.key_extractor, "");
+        assert_eq!(&redis_sink.value_extractor, "");
+    }
+
+    #[test]
+    fn test_mysql_sink_close() {
+        let ref conf = MysqlDesc {
+            connection_opts: Some(mysql_desc::ConnectionOpts {
+                host: "localhost".to_string(),
+                username: "root".to_string(),
+                password: "123".to_string(),
+                database: "test".to_string(),
+            }),
+            statement: Some(mysql_desc::Statement {
+                statement: "statement".to_string(),
+                extractors: vec![mysql_desc::statement::Extractor {
+                    index: 0,
+                    extractor: "extrator".to_string(),
+                }],
+            }),
+        };
+        let mut mysql_sink = super::Mysql::with_config(0, conf);
+        mysql_sink.close_sink();
+        assert!(mysql_sink.extractors.is_empty());
+        assert!(mysql_sink.statement.is_empty());
     }
 }

--- a/src/stream/src/actor.rs
+++ b/src/stream/src/actor.rs
@@ -2,7 +2,9 @@ use crate::dataflow::DataflowTask;
 use crate::err::{ErrorKind::RemoteSinkFailed, SinkException};
 use crate::state::new_state_mgt;
 use crate::v8_runtime::RuntimeEngine;
+use crate::{EventReceiver, EventSender, DEFAULT_CHANNEL_SIZE};
 
+use async_trait::async_trait;
 use common::collections::lang;
 use common::db::MysqlConn;
 use common::event::{LocalEvent, SinkableMessage, SinkableMessageImpl};
@@ -10,7 +12,8 @@ use common::kafka::{run_consumer, run_producer, KafkaConsumer, KafkaMessage, Kaf
 
 use common::redis::RedisClient;
 use common::types::{ExecutorId, SinkId, SourceId, TypedValue};
-use common::utils;
+use common::utils::{self, get_env};
+use prost::Message;
 use prost_types::Timestamp;
 
 use proto::common::{sink, source, DataflowMeta, KafkaDesc, MysqlDesc, OperatorInfo, RedisDesc};
@@ -26,9 +29,6 @@ use rayon::prelude::*;
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::vec;
-
-pub type EventReceiver<Input> = tokio::sync::mpsc::UnboundedReceiver<Input>;
-pub type EventSender<Input> = tokio::sync::mpsc::UnboundedSender<Input>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DataflowContext {
@@ -130,6 +130,7 @@ impl DataflowContext {
 pub trait Executor {
     fn run(&mut self);
     fn as_sinkable(&self) -> SinkImpl;
+    fn close(&mut self);
 }
 
 #[derive(Clone)]
@@ -164,57 +165,51 @@ impl Executor for LocalExecutor {
     fn run(&mut self) {
         use LocalEvent::KeyedDataStreamEvent;
         use SinkableMessageImpl::LocalMessage;
-        match self.source {
-            SourceImpl::Empty(_) => {}
-            _ => {
-                let isolate = &mut v8::Isolate::new(Default::default());
-                let scope = &mut v8::HandleScope::new(isolate);
-                let task =
-                    DataflowTask::new(self.operator.clone(), new_state_mgt(&self.job_id), scope);
-                loop {
-                    while let Some(msg) = self.source.fetch_msg() {
-                        match &msg {
-                            LocalMessage(message) => match message {
-                                KeyedDataStreamEvent(e) => {
-                                    if self.operator.has_source() || self.operator.has_sink() {
+        let isolate = &mut v8::Isolate::new(Default::default());
+        let scope = &mut v8::HandleScope::new(isolate);
+        let task = DataflowTask::new(&self.operator, new_state_mgt(&self.job_id), scope);
+        loop {
+            while let Some(msg) = self.source.fetch_msg() {
+                match &msg {
+                    LocalMessage(message) => match message {
+                        KeyedDataStreamEvent(e) => {
+                            if self.operator.has_source() || self.operator.has_sink() {
+                                self.sinks.par_iter().for_each(|sink| {
+                                    let _ = futures_executor::block_on(sink.sink(msg.clone()));
+                                });
+                            } else {
+                                match task.process(e) {
+                                    Ok(results) => results.iter().for_each(|event| {
+                                        let after_process = KeyedDataStreamEvent(event.clone());
                                         self.sinks.par_iter().for_each(|sink| {
-                                            let _ =
-                                                futures_executor::block_on(sink.sink(msg.clone()));
-                                        });
-                                    } else {
-                                        match task.process(e) {
-                                            Ok(results) => results.iter().for_each(|event| {
-                                                let after_process =
-                                                    KeyedDataStreamEvent(event.clone());
-                                                self.sinks.par_iter().for_each(|sink| {
-                                                    let result =
-                                                        futures_executor::block_on(sink.sink(
-                                                            LocalMessage(after_process.clone()),
-                                                        ));
-                                                    match result {
-                                                        Ok(_) => {}
-                                                        Err(err) => tracing::error!(
-                                                            "sink to node {} failed: {:?}",
-                                                            sink.sink_id(),
-                                                            err
-                                                        ),
-                                                    }
-                                                });
-                                            }),
-                                            Err(err) => {
-                                                tracing::error!("process msg failed: {:?}", err);
-                                                // TODO fault tolerance
+                                            let result = futures_executor::block_on(
+                                                sink.sink(LocalMessage(after_process.clone())),
+                                            );
+                                            match result {
+                                                Ok(_) => {}
+                                                Err(err) => tracing::error!(
+                                                    "sink to node {} failed: {:?}",
+                                                    sink.sink_id(),
+                                                    err
+                                                ),
                                             }
-                                        }
+                                        });
+                                    }),
+                                    Err(err) => {
+                                        tracing::error!("process msg failed: {:?}", err);
+                                        // TODO fault tolerance
                                     }
                                 }
-                                LocalEvent::Terminate { job_id, to } => {
-                                    tracing::info!("stopping {:?} at node id {}", job_id, to);
-                                    return;
-                                }
-                            },
+                            }
                         }
-                    }
+                        LocalEvent::Terminate { job_id, to } => {
+                            tracing::info!("stopping {:?} at node id {}", job_id, to);
+
+                            // gracefully close
+                            self.close();
+                            return;
+                        }
+                    },
                 }
             }
         }
@@ -225,6 +220,15 @@ impl Executor for LocalExecutor {
             sender: self.source.create_msg_sender(),
             sink_id: self.executor_id as u32,
         })
+    }
+
+    fn close(&mut self) {
+        self.job_id.clear();
+        self.operator.clear();
+        drop(self.executor_id);
+        self.sinks.iter_mut().for_each(|sink| sink.close_sink());
+        self.sinks.clear();
+        self.source.close()
     }
 }
 
@@ -237,9 +241,9 @@ unsafe impl Send for ExecutorImpl {}
 unsafe impl Sync for ExecutorImpl {}
 
 impl ExecutorImpl {
-    pub fn run(&mut self) {
+    pub fn run(self) {
         match self {
-            ExecutorImpl::Local(exec) => exec.run(),
+            ExecutorImpl::Local(mut exec) => exec.run(),
         }
     }
 
@@ -254,8 +258,13 @@ impl ExecutorImpl {
 Source Interface. Each Source should implement it
  */
 pub trait Source {
+    /**
+     * Fetch next message
+     * It may block currrent thread
+     */
     fn fetch_msg(&mut self) -> Option<SinkableMessageImpl>;
     fn source_id(&self) -> SourceId;
+    fn close_source(&mut self);
 }
 
 pub struct SourceSinkManger {
@@ -284,7 +293,10 @@ impl SourceSinkManger {
         if self.sources.contains_key(executor_id) {
             return;
         }
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let channel_size = get_env("CHANNEL_SIZE")
+            .and_then(|size| size.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CHANNEL_SIZE);
+        let (tx, rx) = tokio::sync::mpsc::channel(channel_size);
         let recv = Rc::new(rx);
         let source = LocalSource {
             recv,
@@ -329,13 +341,14 @@ impl SourceSinkManger {
             .iter()
             .for_each(|desc| match desc {
                 source::Desc::Kafka(conf) => {
+                    let (tx, rx) = tokio::sync::mpsc::channel(1);
                     self.sources.insert(
                         *executor_id,
-                        SourceImpl::Kafka(Kafka::with_source_config(
-                            &self.job_id,
-                            *executor_id,
-                            conf,
-                        )),
+                        SourceImpl::Kafka(
+                            Kafka::with_source_config(&self.job_id, *executor_id, conf),
+                            tx,
+                            Rc::new(rx),
+                        ),
                     );
                 }
             })
@@ -368,8 +381,11 @@ impl SourceSinkManger {
     }
 
     fn create_empty_source(&mut self, executor_id: &u32) {
-        self.sources
-            .insert(*executor_id, SourceImpl::Empty(*executor_id));
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        self.sources.insert(
+            *executor_id,
+            SourceImpl::Empty(*executor_id, tx, Rc::new(rx)),
+        );
     }
 
     fn create_empty_sink(&mut self, executor_id: &u32) {
@@ -388,13 +404,14 @@ impl SourceSinkManger {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 pub trait Sink {
     fn sink_id(&self) -> SinkId;
     async fn sink(
         &self,
         msg: SinkableMessageImpl,
     ) -> Result<DispatchDataEventStatusEnum, SinkException>;
+    fn close_sink(&mut self);
 }
 
 #[derive(Clone)]
@@ -403,7 +420,7 @@ pub struct LocalSink {
     pub(crate) sink_id: SinkId,
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for LocalSink {
     fn sink_id(&self) -> SinkId {
         self.sink_id
@@ -417,9 +434,15 @@ impl Sink for LocalSink {
             SinkableMessageImpl::LocalMessage(_) => self
                 .sender
                 .send(msg)
+                .await
                 .map(|_| DispatchDataEventStatusEnum::Done)
                 .map_err(|err| err.into()),
         }
+    }
+
+    fn close_sink(&mut self) {
+        futures_executor::block_on(self.sender.closed());
+        drop(self.sink_id)
     }
 }
 
@@ -429,7 +452,7 @@ pub struct RemoteSink {
     pub(crate) host_addr: HostAddr,
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for RemoteSink {
     fn sink_id(&self) -> SinkId {
         self.sink_id
@@ -491,6 +514,11 @@ impl Sink for RemoteSink {
             Err(err) => Err(err),
         }
     }
+
+    fn close_sink(&mut self) {
+        drop(self.sink_id);
+        self.host_addr.clear();
+    }
 }
 
 #[derive(Clone)]
@@ -508,6 +536,14 @@ impl Source for LocalSource {
     fn source_id(&self) -> SourceId {
         self.source_id
     }
+
+    fn close_source(&mut self) {
+        Rc::get_mut(&mut self.recv)
+            .iter_mut()
+            .for_each(|recv| recv.close());
+        futures_executor::block_on(self.tx.closed());
+        drop(self.source_id)
+    }
 }
 
 impl LocalSource {
@@ -519,29 +555,68 @@ impl LocalSource {
 #[derive(Clone)]
 pub enum SourceImpl {
     Local(LocalSource),
-    Kafka(Kafka),
-    Empty(SourceId),
+    Kafka(
+        Kafka,
+        EventSender<SinkableMessageImpl>,
+        Rc<EventReceiver<SinkableMessageImpl>>,
+    ),
+    Empty(
+        SourceId,
+        EventSender<SinkableMessageImpl>,
+        Rc<EventReceiver<SinkableMessageImpl>>,
+    ),
 }
 
 impl SourceImpl {
     fn create_msg_sender(&self) -> EventSender<SinkableMessageImpl> {
-        let zero_tx = || -> EventSender<SinkableMessageImpl> {
-            let (tx, _) = tokio::sync::mpsc::unbounded_channel();
-            tx
-        };
-
         match self {
             SourceImpl::Local(source) => source.create_msg_sender(),
-            SourceImpl::Kafka(_) => zero_tx(),
-            SourceImpl::Empty(_) => zero_tx(),
+            SourceImpl::Kafka(.., terminator_tx, _) => terminator_tx.clone(),
+            SourceImpl::Empty(.., terminator_tx, _) => terminator_tx.clone(),
         }
     }
 
     fn fetch_msg(&mut self) -> Option<SinkableMessageImpl> {
         match self {
             SourceImpl::Local(source) => source.fetch_msg(),
-            SourceImpl::Kafka(source) => source.fetch_msg(),
-            SourceImpl::Empty(_) => None,
+            SourceImpl::Kafka(source, _, terminator_rx) => Rc::get_mut(terminator_rx)
+                // should not block thread
+                .and_then(|rx| match rx.try_recv() {
+                    Ok(message) => Some(message),
+                    Err(err) => match err {
+                        // if channel has been close, it will terminate all actors
+                        tokio::sync::mpsc::error::TryRecvError::Disconnected => {
+                            Some(SinkableMessageImpl::LocalMessage(LocalEvent::Terminate {
+                                job_id: source.job_id.clone(),
+                                to: source.source_id(),
+                            }))
+                        }
+                        _ => None,
+                    },
+                })
+                // if there's no terminate signal, go on
+                .or_else(|| source.fetch_msg()),
+            SourceImpl::Empty(.., terminator_rx) => match Rc::get_mut(terminator_rx) {
+                // block until receive terminate signal
+                Some(rx) => futures_executor::block_on(rx.recv()),
+                None => None,
+            },
+        }
+    }
+
+    fn close(&mut self) {
+        match self {
+            SourceImpl::Local(source) => source.close_source(),
+            SourceImpl::Kafka(kafka, tx, rx) => {
+                kafka.close_source();
+                futures_executor::block_on(tx.closed());
+                Rc::get_mut(rx).iter_mut().for_each(|recv| recv.close());
+            }
+            SourceImpl::Empty(id, tx, rx) => {
+                drop(id);
+                futures_executor::block_on(tx.closed());
+                Rc::get_mut(rx).iter_mut().for_each(|recv| recv.close());
+            }
         }
     }
 }
@@ -556,7 +631,7 @@ pub enum SinkImpl {
     Empty(SinkId),
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for SinkImpl {
     fn sink_id(&self) -> SinkId {
         match self {
@@ -580,6 +655,17 @@ impl Sink for SinkImpl {
             SinkImpl::Mysql(sink) => sink.sink(msg).await,
             SinkImpl::Empty(_) => Ok(DispatchDataEventStatusEnum::Done),
             SinkImpl::Redis(redis) => redis.sink(msg).await,
+        }
+    }
+
+    fn close_sink(&mut self) {
+        match self {
+            SinkImpl::Local(sink) => sink.close_sink(),
+            SinkImpl::Remote(sink) => sink.close_sink(),
+            SinkImpl::Kafka(sink) => sink.close_sink(),
+            SinkImpl::Mysql(sink) => sink.close_sink(),
+            SinkImpl::Redis(sink) => sink.close_sink(),
+            SinkImpl::Empty(id) => drop(id),
         }
     }
 }
@@ -662,25 +748,28 @@ impl Kafka {
         let val = TypedValue::from_slice_with_type(payload, data_type);
         let datetime = chrono::DateTime::<chrono::Utc>::from(SystemTime::now());
 
-        SinkableMessageImpl::LocalMessage(LocalEvent::KeyedDataStreamEvent(KeyedDataEvent {
-            job_id: Some(self.job_id.clone()),
-            key: Some(Entry {
-                data_type: key.get_type() as i32,
-                value: key.get_data(),
-            }),
-            to_operator_id: 0,
-            data: vec![Entry {
-                data_type: self.conf.data_type() as i32,
-                value: val.get_data(),
-            }],
-            event_time: Some(Timestamp {
-                seconds: datetime.naive_utc().timestamp(),
-                nanos: datetime.naive_utc().timestamp_subsec_nanos() as i32,
-            }),
-            process_time: None,
-            from_operator_id: self.connector_id,
-            window: None,
-        }))
+        let result =
+            SinkableMessageImpl::LocalMessage(LocalEvent::KeyedDataStreamEvent(KeyedDataEvent {
+                job_id: Some(self.job_id.clone()),
+                key: Some(Entry {
+                    data_type: key.get_type() as i32,
+                    value: key.get_data(),
+                }),
+                to_operator_id: 0,
+                data: vec![Entry {
+                    data_type: self.conf.data_type() as i32,
+                    value: val.get_data(),
+                }],
+                event_time: Some(Timestamp {
+                    seconds: datetime.naive_utc().timestamp(),
+                    nanos: datetime.naive_utc().timestamp_subsec_nanos() as i32,
+                }),
+                process_time: None,
+                from_operator_id: self.connector_id,
+                window: None,
+            }));
+
+        result
     }
 }
 
@@ -697,9 +786,18 @@ impl Source for Kafka {
     fn source_id(&self) -> SourceId {
         self.connector_id
     }
+
+    fn close_source(&mut self) {
+        self.conf.clear();
+        drop(self.connector_id);
+        self.consumer.iter().for_each(|consumer| {
+            consumer.unsubscribe();
+            drop(consumer)
+        })
+    }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for Kafka {
     fn sink_id(&self) -> SinkId {
         self.connector_id
@@ -730,6 +828,15 @@ impl Sink for Kafka {
             }
             None => Ok(DispatchDataEventStatusEnum::Done),
         }
+    }
+
+    fn close_sink(&mut self) {
+        drop(self.connector_id);
+        self.conf.clear();
+        self.job_id.clear();
+        self.producer
+            .iter_mut()
+            .for_each(|producer| producer.close())
     }
 }
 
@@ -775,7 +882,7 @@ impl Mysql {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for Mysql {
     fn sink_id(&self) -> SinkId {
         self.connector_id
@@ -804,6 +911,13 @@ impl Sink for Mysql {
             }
             Err(err) => Err(err.into()),
         }
+    }
+
+    fn close_sink(&mut self) {
+        self.conn.close();
+        self.extractors.clear();
+        drop(self.connector_id);
+        self.statement.clear();
     }
 }
 
@@ -837,7 +951,7 @@ impl Redis {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Sink for Redis {
     fn sink_id(&self) -> SinkId {
         self.connector_id
@@ -863,6 +977,12 @@ impl Sink for Redis {
                     .map(|_| DispatchDataEventStatusEnum::Done)
                     .map_err(|err| err.into())
             })
+    }
+
+    fn close_sink(&mut self) {
+        drop(self.connector_id);
+        self.key_extractor.clear();
+        self.value_extractor.clear();
     }
 }
 

--- a/src/stream/src/actor.rs
+++ b/src/stream/src/actor.rs
@@ -440,6 +440,7 @@ impl Sink for LocalSink {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         futures_executor::block_on(self.sender.closed());
         drop(self.sink_id)
@@ -515,6 +516,7 @@ impl Sink for RemoteSink {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         drop(self.sink_id);
         self.host_addr.clear();
@@ -658,6 +660,7 @@ impl Sink for SinkImpl {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         match self {
             SinkImpl::Local(sink) => sink.close_sink(),
@@ -830,6 +833,7 @@ impl Sink for Kafka {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         drop(self.connector_id);
         self.conf.clear();
@@ -913,6 +917,7 @@ impl Sink for Mysql {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         self.conn.close();
         self.extractors.clear();
@@ -979,6 +984,7 @@ impl Sink for Redis {
             })
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn close_sink(&mut self) {
         drop(self.connector_id);
         self.key_extractor.clear();

--- a/src/stream/src/dataflow.rs
+++ b/src/stream/src/dataflow.rs
@@ -19,17 +19,17 @@ where
     's: 'i,
 {
     pub fn new(
-        op_info: OperatorInfo,
+        op_info: &OperatorInfo,
         state_manager: S,
         scope: &'i mut HandleScope<'s, ()>,
     ) -> Self {
         let (rt_engine, operator) = if op_info.clone().details.is_some() {
-            let detail = op_info.clone().details.unwrap();
+            let detail = op_info.details.as_ref().unwrap();
             match detail {
                 Details::Mapper(map_value) => (
                     RefCell::new(RuntimeEngine::new(
                         &map_value.get_func().function,
-                        &get_function_name(&op_info),
+                        &get_function_name(op_info),
                         scope,
                     )),
                     OperatorImpl::Map(MapOperator::new(&op_info, state_manager)),
@@ -37,34 +37,34 @@ where
                 Details::Filter(filter_value) => (
                     RefCell::new(RuntimeEngine::new(
                         &filter_value.get_func().function,
-                        &get_function_name(&op_info),
+                        &get_function_name(op_info),
                         scope,
                     )),
-                    OperatorImpl::Filter(FilterOperator::new(&op_info, state_manager)),
+                    OperatorImpl::Filter(FilterOperator::new(op_info, state_manager)),
                 ),
                 Details::KeyBy(key_by_value) => (
                     RefCell::new(RuntimeEngine::new(
                         &key_by_value.get_func().function,
-                        &get_function_name(&op_info),
+                        &get_function_name(op_info),
                         scope,
                     )),
-                    OperatorImpl::KeyBy(KeyByOperator::new(&op_info, state_manager)),
+                    OperatorImpl::KeyBy(KeyByOperator::new(op_info, state_manager)),
                 ),
                 Details::Reducer(reduce_value) => (
                     RefCell::new(RuntimeEngine::new(
                         &reduce_value.get_func().function,
-                        &get_function_name(&op_info),
+                        &get_function_name(op_info),
                         scope,
                     )),
-                    OperatorImpl::Reduce(ReduceOperator::new(&op_info, state_manager)),
+                    OperatorImpl::Reduce(ReduceOperator::new(op_info, state_manager)),
                 ),
                 Details::FlatMap(flat_map_value) => (
                     RefCell::new(RuntimeEngine::new(
                         &flat_map_value.get_func().function,
-                        &get_function_name(&op_info),
+                        &get_function_name(op_info),
                         scope,
                     )),
-                    OperatorImpl::FlatMap(FlatMapOperator::new(&op_info, state_manager)),
+                    OperatorImpl::FlatMap(FlatMapOperator::new(op_info, state_manager)),
                 ),
                 _ => (
                     RefCell::new(RuntimeEngine::new("", "", scope)),

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -5,6 +5,10 @@ pub mod state;
 pub mod v8_runtime;
 
 pub(crate) static MOD_TEST_START: std::sync::Once = std::sync::Once::new();
+pub(crate) const DEFAULT_CHANNEL_SIZE: usize = 1000;
+
+pub type EventReceiver<Input> = tokio::sync::mpsc::Receiver<Input>;
+pub type EventSender<Input> = tokio::sync::mpsc::Sender<Input>;
 
 pub fn initialize_v8() {
     // v8::V8::set_flags_from_string(

--- a/src/stream/tests/test_actor.rs
+++ b/src/stream/tests/test_actor.rs
@@ -1,0 +1,39 @@
+use std::{rc::Rc, time::Duration};
+
+use common::event::{LocalEvent, SinkableMessageImpl};
+use proto::common::{DataTypeEnum, KafkaDesc, OperatorInfo, ResourceId};
+use stream::actor::{ExecutorImpl, Kafka, LocalExecutor, SinkImpl, SourceImpl};
+
+#[tokio::test]
+async fn test_actor_close() {
+    let job_id = ResourceId {
+        resource_id: "resource_id".to_string(),
+        namespace_id: "ns_id".to_string(),
+    };
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let innert_tx = tx.clone();
+    let source = SourceImpl::Empty(0, tx, Rc::new(rx));
+    let sinks = vec![SinkImpl::Kafka(Kafka::with_sink_config(
+        &job_id,
+        1,
+        &KafkaDesc {
+            brokers: vec!["localhost:9092".to_string()],
+            topic: "topic".to_string(),
+            opts: None,
+            data_type: DataTypeEnum::Object as i32,
+        },
+    ))];
+    let operator = OperatorInfo::default();
+    let executor = LocalExecutor::with_source_and_sink(&job_id, 0, sinks, source, operator);
+    let executor = ExecutorImpl::Local(executor);
+    let handler = tokio::spawn(async { executor.run() });
+    let result = innert_tx
+        .send(SinkableMessageImpl::LocalMessage(LocalEvent::Terminate {
+            job_id,
+            to: 0,
+        }))
+        .await;
+    assert!(result.is_ok());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(handler.is_finished())
+}

--- a/src/worker/src/main.rs
+++ b/src/worker/src/main.rs
@@ -62,11 +62,6 @@ fn main() {
             tracing::info!("service will start at {}", config.port);
 
             initialize_v8();
-            let _ = Server::builder()
-                .timeout(Duration::from_secs(3))
-                .concurrency_limit_per_connection(3)
-                .add_service(server)
-                .serve(addr)
-                .await;
+            let _ = Server::builder().add_service(server).serve(addr).await;
         });
 }


### PR DESCRIPTION
# Description

1. Make a dataflow gracefully close;
2.  using async_trait instead of tonic::async_trait

# Impact Scope
1. terminate dataflow

# Test Suggestions
1. First, you should deploy a dataflow task, `word count` is recommended;
2. You can use Postman to call the grpc api `TerminateDataflow` of Coordinator service to terminate the dataflow
3. check if `word count` task is closed by sending a message to kafka;

# Tag
No tag

