### PR TITLE
[feat-LIG-57]: use rpc gateway to replace directly call the rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,11 +1537,14 @@ name = "proto"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures-executor",
  "prost",
  "prost-types",
  "serde",
+ "tokio",
  "tonic",
  "tonic-build",
+ "tracing",
 ]
 
 [[package]]

--- a/proto/worker/worker.proto
+++ b/proto/worker/worker.proto
@@ -10,27 +10,19 @@ option go_package = "lightflus/runtime/proto";
 
 service TaskWorkerApi {
   rpc Probe(common.ProbeRequest) returns (common.ProbeResponse) {}
-  rpc DispatchDataEvents(DispatchDataEventsRequest) returns (DispatchDataEventsResponse){}
-  rpc StopDataflow(StopDataflowRequest) returns (StopDataflowResponse) {}
+  rpc SendEventToOperator(common.KeyedDataEvent) returns (SendEventToOperatorResponse){}
+  rpc StopDataflow(common.ResourceId) returns (StopDataflowResponse) {}
   rpc CreateSubDataflow(CreateSubDataflowRequest) returns(CreateSubDataflowResponse) {}
 }
 
-message DispatchDataEventsRequest{
-  repeated common.KeyedDataEvent events = 1;
+message SendEventToOperatorResponse {
+  SendEventToOperatorStatusEnum status = 1;
 }
 
-message DispatchDataEventsResponse {
-  map<string, DispatchDataEventStatusEnum> statusSet = 1;
-}
-
-enum DispatchDataEventStatusEnum {
+enum SendEventToOperatorStatusEnum {
   DISPATCHING = 0;
   DONE = 1;
   FAILURE = 2;
-}
-
-message StopDataflowRequest {
-  common.ResourceId job_id = 1;
 }
 
 message StopDataflowResponse {

--- a/src/common/src/err.rs
+++ b/src/common/src/err.rs
@@ -274,6 +274,7 @@ pub enum TaskWorkerError {
     ChannelDisconnected,
     ChannelEmpty,
     ExecutionError(String),
+    EventSendFailure(String),
 }
 
 impl From<mpsc::error::TryRecvError> for TaskWorkerError {

--- a/src/common/src/kafka.rs
+++ b/src/common/src/kafka.rs
@@ -63,27 +63,25 @@ pub struct KafkaProducer {
 }
 
 impl KafkaProducer {
-    pub fn send(&self, key: &[u8], payload: &[u8]) -> Result<(), KafkaException> {
+    pub async fn send(&self, key: &[u8], payload: &[u8]) -> Result<(), KafkaException> {
         if payload.is_empty() {
             Ok(())
         } else {
-            futures_executor::block_on(async {
-                let record = FutureRecord::to(self.topic.as_str())
-                    .partition(self.partition)
-                    .payload(payload)
-                    .key(key);
-                self.producer
-                    .send(record, Duration::from_secs(3))
-                    .await
-                    .map(|(partition, offset)| {
-                        tracing::debug!(
-                            "send message to partition {} with offset {}",
-                            partition,
-                            offset
-                        )
-                    })
-                    .map_err(|err| KafkaException { err: err.0 })
-            })
+            let record = FutureRecord::to(self.topic.as_str())
+                .partition(self.partition)
+                .payload(payload)
+                .key(key);
+            self.producer
+                .send(record, Duration::from_secs(3))
+                .await
+                .map(|(partition, offset)| {
+                    tracing::debug!(
+                        "send message to partition {} with offset {}",
+                        partition,
+                        offset
+                    )
+                })
+                .map_err(|err| KafkaException { err: err.0 })
         }
     }
 

--- a/src/common/tests/test_kafka.rs
+++ b/src/common/tests/test_kafka.rs
@@ -19,9 +19,9 @@ async fn test_kafka_pub_sub() {
     let producer = run_producer(format!("{}:9092", kafka_host).as_str(), "ci", "ci_group", 0);
     assert!(producer.is_ok());
     let producer = producer.unwrap();
-    let send_result = producer.send("key".as_bytes(), "value".as_bytes());
+    let send_result = producer.send("key".as_bytes(), "value".as_bytes()).await;
     if send_result.is_err() {
-        let send_result = producer.send("key".as_bytes(), "value".as_bytes());
+        let send_result = producer.send("key".as_bytes(), "value".as_bytes()).await;
         assert!(send_result.is_ok());
     } else {
         assert!(send_result.is_ok());

--- a/src/coordinator/src/api.rs
+++ b/src/coordinator/src/api.rs
@@ -10,15 +10,14 @@ use proto::coordinator::{
 };
 use tokio::sync::RwLock;
 
-#[derive(Clone)]
 pub(crate) struct CoordinatorApiImpl {
-    coordinator: Arc<RwLock<coord::Coordinator>>,
+    coordinator: RwLock<coord::Coordinator>,
 }
 
 impl CoordinatorApiImpl {
     pub(crate) fn new(coordinator: coord::Coordinator) -> CoordinatorApiImpl {
         CoordinatorApiImpl {
-            coordinator: Arc::new(RwLock::new(coordinator)),
+            coordinator: RwLock::new(coordinator),
         }
     }
 }

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -11,6 +11,9 @@ prost = "0.11"
 prost-types = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
+tokio = { version = "1", features = ["sync"] }
+futures-executor = "0.3"
+tracing = "0.1"
 
 [features]
 worker = ["proto-common"]

--- a/src/proto/src/common_impl.rs
+++ b/src/proto/src/common_impl.rs
@@ -378,3 +378,9 @@ get_func!(Mapper, mapper);
 get_func!(Reducer, reducer);
 get_func!(KeyBy, key_by);
 get_func!(Filter, filter);
+
+impl HostAddr {
+    pub fn as_uri(&self) -> String {
+        format!("http://{}:{}", &self.host, self.port)
+    }
+}

--- a/src/proto/src/coordinator_gateway.rs
+++ b/src/proto/src/coordinator_gateway.rs
@@ -1,0 +1,102 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::sync::Mutex;
+
+use crate::{
+    common::{Dataflow, HostAddr, ProbeRequest, ProbeResponse},
+    coordinator::{
+        coordinator_api_client::CoordinatorApiClient, CreateDataflowResponse, GetDataflowRequest,
+        GetDataflowResponse, TerminateDataflowRequest, TerminateDataflowResponse,
+    },
+    DEFAULT_CONNECT_TIMEOUT,
+};
+
+/// A thread-safe RpcGateway wrapper for [`CoordinatorApiClient`]. It's also reponsible for concurrency control of client-side gRPC.
+/// [`SafeCoordinatorRpcGateway`] ensures only one thread can call [`CoordinatorApiClient`]. Requests have to be sent FIFO, without any fault tolerance.
+/// [`SafeCoordinatorRpcGateway`] can be shared in different threads safely.
+#[derive(Debug, Clone)]
+pub struct SafeCoordinatorRpcGateway {
+    inner: Arc<Mutex<Option<CoordinatorApiClient<tonic::transport::Channel>>>>,
+    host_addr: HostAddr,
+}
+
+impl SafeCoordinatorRpcGateway {
+    pub fn new(host_addr: &HostAddr) -> Self {
+        let client = futures_executor::block_on(CoordinatorApiClient::connect_with_timeout(
+            host_addr.as_uri(),
+            Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+        ));
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(client.ok())),
+            host_addr: host_addr.clone(),
+        }
+    }
+    pub async fn probe(&self, req: ProbeRequest) -> Result<ProbeResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            CoordinatorApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .probe(tonic::Request::new(req))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn create_dataflow(
+        &self,
+        dataflow: Dataflow,
+    ) -> Result<CreateDataflowResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            CoordinatorApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .create_dataflow(tonic::Request::new(dataflow))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn terminate_dataflow(
+        &self,
+        req: TerminateDataflowRequest,
+    ) -> Result<TerminateDataflowResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            CoordinatorApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .terminate_dataflow(tonic::Request::new(req))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn get_dataflow(
+        &self,
+        req: GetDataflowRequest,
+    ) -> Result<GetDataflowResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            CoordinatorApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .get_dataflow(tonic::Request::new(req))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+}

--- a/src/proto/src/coordinator_impl.rs
+++ b/src/proto/src/coordinator_impl.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use tonic::codegen::StdError;
+
+use crate::coordinator::coordinator_api_client::CoordinatorApiClient;
+
+/// Extra implementation of [`CoordinatorApiClient`]
+impl CoordinatorApiClient<tonic::transport::Channel> {
+    /// Connect to remote coordinator lazily with connection timeout
+    pub fn with_connection_timeout<D>(dst: D, timeout: Duration) -> Self
+    where
+        D: TryInto<tonic::transport::Endpoint>,
+        D::Error: Into<StdError>,
+    {
+        let conn = tonic::transport::Endpoint::new(dst)
+            .expect("parse endpoint failed")
+            .connect_timeout(timeout)
+            .connect_lazy();
+        Self::new(conn)
+    }
+
+    /// Try to connect to remote coordinator with connection timeout
+    pub async fn connect_with_timeout<D>(
+        dst: D,
+        timeout: Duration,
+    ) -> Result<Self, tonic::transport::Error>
+    where
+        D: TryInto<tonic::transport::Endpoint>,
+        D::Error: Into<StdError>,
+    {
+        let conn = tonic::transport::Endpoint::new(dst)?
+            .connect_timeout(timeout)
+            .connect()
+            .await;
+        conn.map(|channel| Self::new(channel))
+    }
+}

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -6,10 +6,24 @@ pub mod common_impl;
 #[cfg(feature = "coordinator")]
 pub mod coordinator;
 
+#[cfg(feature = "coordinator")]
+pub mod coordinator_gateway;
+
+#[cfg(feature = "coordinator")]
+pub mod coordinator_impl;
+
 #[cfg(feature = "worker")]
 pub mod worker;
+
+#[cfg(feature = "worker")]
+pub mod worker_gateway;
+
+#[cfg(feature = "worker")]
+pub mod worker_impl;
 
 #[cfg(feature = "apiserver")]
 pub mod apiserver;
 #[cfg(feature = "apiserver")]
 pub mod apiserver_impl;
+
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: u64 = 3;

--- a/src/proto/src/worker.rs
+++ b/src/proto/src/worker.rs
@@ -1,17 +1,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DispatchDataEventsRequest {
-    #[prost(message, repeated, tag = "1")]
-    pub events: ::prost::alloc::vec::Vec<super::common::KeyedDataEvent>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DispatchDataEventsResponse {
-    #[prost(map = "string, enumeration(DispatchDataEventStatusEnum)", tag = "1")]
-    pub status_set: ::std::collections::HashMap<::prost::alloc::string::String, i32>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StopDataflowRequest {
-    #[prost(message, optional, tag = "1")]
-    pub job_id: ::core::option::Option<super::common::ResourceId>,
+pub struct SendEventToOperatorResponse {
+    #[prost(enumeration = "SendEventToOperatorStatusEnum", tag = "1")]
+    pub status: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StopDataflowResponse {
@@ -32,21 +22,21 @@ pub struct CreateSubDataflowResponse {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum DispatchDataEventStatusEnum {
+pub enum SendEventToOperatorStatusEnum {
     Dispatching = 0,
     Done = 1,
     Failure = 2,
 }
-impl DispatchDataEventStatusEnum {
+impl SendEventToOperatorStatusEnum {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            DispatchDataEventStatusEnum::Dispatching => "DISPATCHING",
-            DispatchDataEventStatusEnum::Done => "DONE",
-            DispatchDataEventStatusEnum::Failure => "FAILURE",
+            SendEventToOperatorStatusEnum::Dispatching => "DISPATCHING",
+            SendEventToOperatorStatusEnum::Done => "DONE",
+            SendEventToOperatorStatusEnum::Failure => "FAILURE",
         }
     }
 }
@@ -141,10 +131,10 @@ pub mod task_worker_api_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        pub async fn dispatch_data_events(
+        pub async fn send_event_to_operator(
             &mut self,
-            request: impl tonic::IntoRequest<super::DispatchDataEventsRequest>,
-        ) -> Result<tonic::Response<super::DispatchDataEventsResponse>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::super::common::KeyedDataEvent>,
+        ) -> Result<tonic::Response<super::SendEventToOperatorResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -156,13 +146,13 @@ pub mod task_worker_api_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/worker.TaskWorkerApi/DispatchDataEvents",
+                "/worker.TaskWorkerApi/SendEventToOperator",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn stop_dataflow(
             &mut self,
-            request: impl tonic::IntoRequest<super::StopDataflowRequest>,
+            request: impl tonic::IntoRequest<super::super::common::ResourceId>,
         ) -> Result<tonic::Response<super::StopDataflowResponse>, tonic::Status> {
             self.inner
                 .ready()
@@ -211,13 +201,13 @@ pub mod task_worker_api_server {
             &self,
             request: tonic::Request<super::super::common::ProbeRequest>,
         ) -> Result<tonic::Response<super::super::common::ProbeResponse>, tonic::Status>;
-        async fn dispatch_data_events(
+        async fn send_event_to_operator(
             &self,
-            request: tonic::Request<super::DispatchDataEventsRequest>,
-        ) -> Result<tonic::Response<super::DispatchDataEventsResponse>, tonic::Status>;
+            request: tonic::Request<super::super::common::KeyedDataEvent>,
+        ) -> Result<tonic::Response<super::SendEventToOperatorResponse>, tonic::Status>;
         async fn stop_dataflow(
             &self,
-            request: tonic::Request<super::StopDataflowRequest>,
+            request: tonic::Request<super::super::common::ResourceId>,
         ) -> Result<tonic::Response<super::StopDataflowResponse>, tonic::Status>;
         async fn create_sub_dataflow(
             &self,
@@ -321,25 +311,25 @@ pub mod task_worker_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/worker.TaskWorkerApi/DispatchDataEvents" => {
+                "/worker.TaskWorkerApi/SendEventToOperator" => {
                     #[allow(non_camel_case_types)]
-                    struct DispatchDataEventsSvc<T: TaskWorkerApi>(pub Arc<T>);
+                    struct SendEventToOperatorSvc<T: TaskWorkerApi>(pub Arc<T>);
                     impl<
                         T: TaskWorkerApi,
-                    > tonic::server::UnaryService<super::DispatchDataEventsRequest>
-                    for DispatchDataEventsSvc<T> {
-                        type Response = super::DispatchDataEventsResponse;
+                    > tonic::server::UnaryService<super::super::common::KeyedDataEvent>
+                    for SendEventToOperatorSvc<T> {
+                        type Response = super::SendEventToOperatorResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::DispatchDataEventsRequest>,
+                            request: tonic::Request<super::super::common::KeyedDataEvent>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
-                                (*inner).dispatch_data_events(request).await
+                                (*inner).send_event_to_operator(request).await
                             };
                             Box::pin(fut)
                         }
@@ -349,7 +339,7 @@ pub mod task_worker_api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = DispatchDataEventsSvc(inner);
+                        let method = SendEventToOperatorSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -366,7 +356,7 @@ pub mod task_worker_api_server {
                     struct StopDataflowSvc<T: TaskWorkerApi>(pub Arc<T>);
                     impl<
                         T: TaskWorkerApi,
-                    > tonic::server::UnaryService<super::StopDataflowRequest>
+                    > tonic::server::UnaryService<super::super::common::ResourceId>
                     for StopDataflowSvc<T> {
                         type Response = super::StopDataflowResponse;
                         type Future = BoxFuture<
@@ -375,7 +365,7 @@ pub mod task_worker_api_server {
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::StopDataflowRequest>,
+                            request: tonic::Request<super::super::common::ResourceId>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {

--- a/src/proto/src/worker_gateway.rs
+++ b/src/proto/src/worker_gateway.rs
@@ -1,0 +1,111 @@
+use std::{sync::Arc, time::Duration};
+
+use prost::Message;
+
+use crate::{
+    common::{HostAddr, KeyedDataEvent, ProbeRequest, ProbeResponse, ResourceId},
+    worker::{
+        task_worker_api_client::TaskWorkerApiClient, CreateSubDataflowRequest,
+        CreateSubDataflowResponse, SendEventToOperatorResponse, StopDataflowResponse,
+    },
+    DEFAULT_CONNECT_TIMEOUT,
+};
+
+/// A thread-safe RpcGateway wrapper for [`TaskWorkerApiClient`]. It's also reponsible for concurrency control of client-side gRPC.
+/// [`SafeTaskWorkerRpcGateway`] ensures only one thread can call [`TaskWorkerApiClient`]. Requests have to be sent FIFO, without any fault tolerance.
+/// [`SafeTaskWorkerRpcGateway`] can be shared in different threads safely.
+#[derive(Debug, Clone)]
+pub struct SafeTaskWorkerRpcGateway {
+    inner: Arc<tokio::sync::Mutex<Option<TaskWorkerApiClient<tonic::transport::Channel>>>>,
+    host_addr: HostAddr,
+}
+
+unsafe impl Send for SafeTaskWorkerRpcGateway {}
+unsafe impl Sync for SafeTaskWorkerRpcGateway {}
+
+impl SafeTaskWorkerRpcGateway {
+    pub fn new(host_addr: &HostAddr) -> Self {
+        let client = TaskWorkerApiClient::with_connection_timeout(
+            host_addr.as_uri(),
+            Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+        );
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(Some(client))),
+            host_addr: host_addr.clone(),
+        }
+    }
+
+    pub async fn probe(&self, req: ProbeRequest) -> Result<ProbeResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            TaskWorkerApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .probe(tonic::Request::new(req))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn send_event_to_operator(
+        &self,
+        event: KeyedDataEvent,
+    ) -> Result<SendEventToOperatorResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            TaskWorkerApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .send_event_to_operator(tonic::Request::new(event))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn stop_dataflow(
+        &self,
+        job_id: ResourceId,
+    ) -> Result<StopDataflowResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            TaskWorkerApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .stop_dataflow(tonic::Request::new(job_id))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub async fn create_sub_dataflow(
+        &self,
+        req: CreateSubDataflowRequest,
+    ) -> Result<CreateSubDataflowResponse, tonic::Status> {
+        let mut guard = self.inner.lock().await;
+        let inner = guard.get_or_insert_with(|| {
+            TaskWorkerApiClient::with_connection_timeout(
+                self.host_addr.as_uri(),
+                Duration::from_secs(DEFAULT_CONNECT_TIMEOUT),
+            )
+        });
+
+        inner
+            .create_sub_dataflow(tonic::Request::new(req))
+            .await
+            .map(|resp| resp.into_inner())
+    }
+
+    pub fn close(&mut self) {
+        self.host_addr.clear();
+        drop(self.inner.as_ref())
+    }
+}

--- a/src/proto/src/worker_impl.rs
+++ b/src/proto/src/worker_impl.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+use tonic::codegen::StdError;
+
+use crate::worker::task_worker_api_client::TaskWorkerApiClient;
+
+/// Extra implementation of [`TaskWorkerApiClient`]
+impl TaskWorkerApiClient<tonic::transport::Channel> {
+    /// Connect to remote task worker lazily with connection timeout
+    pub fn with_connection_timeout<D>(dst: D, timeout: Duration) -> Self
+    where
+        D: TryInto<tonic::transport::Endpoint>,
+        D::Error: Into<StdError>,
+    {
+        let conn = tonic::transport::Endpoint::new(dst)
+            .expect("parse endpoint failed")
+            .connect_timeout(timeout)
+            .connect_lazy();
+        Self::new(conn)
+    }
+
+    /// Try to connect to remote task worker with connection timeout
+    pub async fn connect_with_timeout<D>(dst: D, timeout: Duration) -> Result<Self, ConnectionError>
+    where
+        D: TryInto<tonic::transport::Endpoint>,
+        D::Error: Into<StdError>,
+    {
+        match tonic::transport::Endpoint::new(dst) {
+            Ok(endpoint) => match tokio::time::timeout(timeout, endpoint.connect()).await {
+                Ok(result) => result
+                    .map(|conn| Self::new(conn))
+                    .map_err(|err| ConnectionError::Transport(err)),
+                Err(err) => {
+                    tracing::error!("connect to remote task worker timeout. {}", err);
+                    Err(ConnectionError::Timeout)
+                }
+            },
+            Err(err) => Err(ConnectionError::Transport(err)),
+        }
+    }
+}
+
+pub enum ConnectionError {
+    Timeout,
+    Transport(tonic::transport::Error),
+}

--- a/src/stream/src/actor.rs
+++ b/src/stream/src/actor.rs
@@ -616,7 +616,7 @@ impl Sink for RemoteSink {
     ) -> Result<SendEventToOperatorStatusEnum, SinkException> {
         match msg {
             SinkableMessageImpl::LocalMessage(event) => match event {
-                LocalEvent::Terminate { job_id, .. } => Ok(SendEventToOperatorStatusEnum::Done),
+                LocalEvent::Terminate { .. } => Ok(SendEventToOperatorStatusEnum::Done),
                 LocalEvent::KeyedDataStreamEvent(e) => self
                     .task_worker_gateway
                     .send_event_to_operator(e)

--- a/src/stream/src/err.rs
+++ b/src/stream/src/err.rs
@@ -1,5 +1,5 @@
 use common::{
-    err::{KafkaException, RedisException},
+    err::{KafkaException, RedisException, TaskWorkerError},
     event::{KafkaEventError, SinkableMessageImpl},
 };
 use tokio::sync::mpsc::error::SendError;
@@ -18,6 +18,12 @@ pub enum ErrorKind {
 pub struct SinkException {
     pub kind: ErrorKind,
     pub msg: String,
+}
+
+impl SinkException {
+    pub fn into_task_worker_error(&self) -> TaskWorkerError {
+        TaskWorkerError::EventSendFailure(format!("{:?}", self))
+    }
 }
 
 impl From<SendError<SinkableMessageImpl>> for SinkException {

--- a/src/stream/tests/test_sinks.rs
+++ b/src/stream/tests/test_sinks.rs
@@ -17,7 +17,7 @@ use proto::{
         redis_desc, DataTypeEnum, Entry, Func, KafkaDesc, KeyedDataEvent, MysqlDesc, RedisDesc,
         ResourceId,
     },
-    worker::DispatchDataEventStatusEnum,
+    worker::SendEventToOperatorStatusEnum,
 };
 use sqlx::Row;
 use stream::actor::{Kafka, Mysql, Redis, Sink, SinkImpl};
@@ -115,7 +115,7 @@ async fn test_kafka_sink() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status, DispatchDataEventStatusEnum::Done);
+    assert_eq!(status, SendEventToOperatorStatusEnum::Done);
 
     fn processor(message: KafkaMessage) {
         let key = serde_json::from_slice::<serde_json::Value>(&message.key);
@@ -312,7 +312,7 @@ async fn test_mysql_sink() {
         ))
         .await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), DispatchDataEventStatusEnum::Done);
+    assert_eq!(result.unwrap(), SendEventToOperatorStatusEnum::Done);
 
     let result = conn
         .try_for_each(

--- a/src/stream/tests/test_sources.rs
+++ b/src/stream/tests/test_sources.rs
@@ -34,7 +34,7 @@ async fn test_kafka_source() {
     assert!(producer.is_ok());
     let producer = producer.unwrap();
 
-    let result = producer.send("key".as_bytes(), "value".as_bytes());
+    let result = producer.send("key".as_bytes(), "value".as_bytes()).await;
     assert!(result.is_ok());
     let msg = kafka_source.fetch_msg();
     assert!(msg.is_some());

--- a/src/worker/src/worker.rs
+++ b/src/worker/src/worker.rs
@@ -61,12 +61,12 @@ impl TaskWorker {
 
     pub async fn send_event_to_operator(
         &self,
-        events: &KeyedDataEvent,
+        event: &KeyedDataEvent,
     ) -> Result<SendEventToOperatorStatusEnum, TaskWorkerError> {
         let managers = self.cache.read().await;
-        match managers.get(&events.get_job_id().into()) {
+        match managers.get(&event.get_job_id().into()) {
             Some(manager) => manager
-                .send_event_to_operator(events)
+                .send_event_to_operator(event)
                 .await
                 .map_err(|err| err.into_task_worker_error()),
             None => todo!(),


### PR DESCRIPTION
# Description
In previous version, TaskWorker and Coordinator use gRPC client ugly. We refactor the way to call TaskWorkerApi and CoordinatorApi to make it easier and painless

1. Add `SafeTaskWorkerRpcGateway` which wrap `TaskWorkerApiClient` and control the client-side concurrency request;
2. Add `SafeCoordinatorRpcGateway` which wrap ``CoordinatorApiClient` and control the client-side concurrency request;
3. Use `SafeTaskWorkerRpcGateway` to replace `TaskWorkerApiClient` in worker;

# Impact Scope
1. coordinator call worker's rpc

# Test Suggestions
1. `SafeTaskWorkerRpcGateway` will successfully call `TaskWorkerApiClient`

